### PR TITLE
Editor CSS Change Fixes Logo Moving on Different Pages

### DIFF
--- a/src/new-page/editor.css
+++ b/src/new-page/editor.css
@@ -45,8 +45,13 @@
     font-size: 1.5rem;
     text-decoration: none;
     color: var(--text-navbar);
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     padding: 0.5rem 1rem;
-    border-radius: 8px;
+    border-radius: 50%;
     transition: background-color 0.3s ease;
 }
 


### PR DESCRIPTION
Making back button in new-page match the size of the menu on the home page so the logo does not move between pages