### PR TITLE
Fixes New Page Light/Dark Toggle Button

### DIFF
--- a/src/new-page/editor-script.js
+++ b/src/new-page/editor-script.js
@@ -1,0 +1,44 @@
+// DOM Elements
+const overlay = document.querySelector('.overlay');
+const themeToggle = document.querySelector('.theme-toggle');
+const lightModeIcon = document.querySelector('.light-mode');
+const darkModeIcon = document.querySelector('.dark-mode');
+
+// Theme Toggle Function
+function toggleTheme() {
+    const html = document.documentElement;
+    const currentTheme = html.getAttribute('data-theme');
+    const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+    
+    html.setAttribute('data-theme', newTheme);
+    
+    // Toggle icon visibility
+    if (newTheme === 'dark') {
+        lightModeIcon.style.display = 'none';
+        darkModeIcon.style.display = 'block';
+    } else {
+        lightModeIcon.style.display = 'block';
+        darkModeIcon.style.display = 'none';
+    }
+
+    // Save theme preference
+    localStorage.setItem('theme', newTheme);
+}
+
+// Theme Toggle Event Listener
+themeToggle.addEventListener('click', toggleTheme);
+
+// Load Saved Theme
+function loadSavedTheme() {
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme) {
+        document.documentElement.setAttribute('data-theme', savedTheme);
+        if (savedTheme === 'dark') {
+            lightModeIcon.style.display = 'none';
+            darkModeIcon.style.display = 'block';
+        }
+    }
+}
+
+// Initialize theme on page load
+loadSavedTheme();

--- a/src/new-page/editor.html
+++ b/src/new-page/editor.html
@@ -29,7 +29,7 @@
         </div>
     </main>
 
-    <script src="../script.js"></script>
+    <script src="editor-script.js"></script>
     <script src="editor.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Closes #4. New page-specific script that does not include the home menu and sidebar, implements functional light/dark theme toggle button